### PR TITLE
Add Events before and after upgrade run

### DIFF
--- a/Our.Umbraco.SilentUpgrade/Our.Umbraco.SilentUpgrade.csproj
+++ b/Our.Umbraco.SilentUpgrade/Our.Umbraco.SilentUpgrade.csproj
@@ -230,6 +230,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SilentUpgrade.cs" />
     <Compile Include="SilentUpgradeComponent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Our.Umbraco.SilentUpgrade/SilentUpgrade.cs
+++ b/Our.Umbraco.SilentUpgrade/SilentUpgrade.cs
@@ -14,13 +14,14 @@ namespace Our.Umbraco.SilentUpgrade
         public static event UpgradeEventHandler UpgradeStarting;
         public static event UpgradeEventHandler UpgradeComplete;
 
-        public static void FireUpgradeComplete(bool success, string initialVersion, string finalVersion)
+        public static void FireUpgradeComplete(bool success, string initialVersion, string finalVersion, string message = "")
         {
             UpgradeComplete?.Invoke(new UpgradeEventArgs
             {
                 VersionFrom = initialVersion,
                 VersionTo = finalVersion,
-                Success = success
+                Success = success,
+                Message = message
             });
         }
 

--- a/Our.Umbraco.SilentUpgrade/SilentUpgrade.cs
+++ b/Our.Umbraco.SilentUpgrade/SilentUpgrade.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Web.org.umbraco.update;
+
+namespace Our.Umbraco.SilentUpgrade
+{
+    public delegate void UpgradeEventHandler(UpgradeEventArgs e);
+
+    public class SilentUpgrade
+    {
+        public static event UpgradeEventHandler UpgradeStarting;
+        public static event UpgradeEventHandler UpgradeComplete;
+
+        public static void FireUpgradeComplete(bool success, string initialVersion, string finalVersion)
+        {
+            UpgradeComplete?.Invoke(new UpgradeEventArgs
+            {
+                VersionFrom = initialVersion,
+                VersionTo = finalVersion,
+                Success = success
+            });
+        }
+
+        public static void FireUpgradeStarting(string initialVersion, string targetVersion)
+        {
+            UpgradeStarting?.Invoke(new UpgradeEventArgs
+            {
+                VersionFrom = initialVersion,
+                VersionTo = targetVersion
+            });
+        }
+    }
+
+    public class UpgradeEventArgs
+    {
+        public bool Success { get; set; }
+
+        public string VersionFrom { get; set; }
+        public string VersionTo { get; set; }
+
+        public string Message { get; set; }
+
+    }
+}

--- a/Our.Umbraco.SilentUpgrade/SilentUpgradeComponent.cs
+++ b/Our.Umbraco.SilentUpgrade/SilentUpgradeComponent.cs
@@ -105,6 +105,11 @@ namespace Our.Umbraco.SilentUpgrade
             try
             {
 
+                var initialVersion = globalSettings.ConfigurationStatus;
+                var targetVersion = UmbracoVersion.SemanticVersion.ToSemanticString();
+
+                SilentUpgrade.FireUpgradeStarting(initialVersion, targetVersion);
+
                 //
                 // If these steps change in the core then this will be wrong.
                 //
@@ -131,12 +136,14 @@ namespace Our.Umbraco.SilentUpgrade
                 // Step: 'SetUmbracoVersionStep'
 
                 // Update the version number inside the web.config
-                logger.Debug<SilentUpgradeComponent>("Updating version in the web.config {version}", UmbracoVersion.SemanticVersion.ToSemanticString());
+                logger.Debug<SilentUpgradeComponent>("Updating version in the web.config {version}", targetVersion);
                 // Doing this essentially restats the site.
-                globalSettings.ConfigurationStatus = UmbracoVersion.SemanticVersion.ToSemanticString();
+                globalSettings.ConfigurationStatus = targetVersion;
 
                 // put something in the log.
-                logger.Info<SilentUpgradeComponent>("Silent Upgrade Completed {version}", UmbracoVersion.SemanticVersion.ToSemanticString());
+                logger.Info<SilentUpgradeComponent>("Silent Upgrade Completed {version}", targetVersion);
+
+                SilentUpgrade.FireUpgradeComplete(true, initialVersion, targetVersion);
 
                 Upgraded = true;
             }

--- a/Our.Umbraco.SilentUpgrade/SilentUpgradeComponent.cs
+++ b/Our.Umbraco.SilentUpgrade/SilentUpgradeComponent.cs
@@ -101,12 +101,12 @@ namespace Our.Umbraco.SilentUpgrade
             logger.Debug<SilentUpgradeComponent>("Silently upgrading the Site");
 
             // The 'current' steps for upgrading Umbraco
+            var initialVersion = globalSettings.ConfigurationStatus;
+            var targetVersion = UmbracoVersion.SemanticVersion.ToSemanticString();
 
             try
             {
 
-                var initialVersion = globalSettings.ConfigurationStatus;
-                var targetVersion = UmbracoVersion.SemanticVersion.ToSemanticString();
 
                 SilentUpgrade.FireUpgradeStarting(initialVersion, targetVersion);
 
@@ -149,6 +149,8 @@ namespace Our.Umbraco.SilentUpgrade
             }
             catch(Exception ex)
             {
+                SilentUpgrade.FireUpgradeComplete(false, initialVersion, targetVersion, ex.Message);
+
                 logger.Warn<SilentUpgradeComponent>(ex, "Silent Upgrade Failed");
                 Upgraded = false; // if this is false, we should fall through to the 'standard' upgrade path.
             }


### PR DESCRIPTION
#1 - Adds a UpgradeStarting and UpgradeComplete Event that can been hooked into so you can run things/ notify people when upgrades have happened. 